### PR TITLE
Add Digi-ID focus to intro activity. Fallback block explorer, and NFC is not a requirement.

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -14,7 +14,7 @@
 
     <uses-permission android:name="android.permission.NFC"/>
 
-    <uses-feature android:name="android.hardware.nfc"/>
+    <uses-feature android:name="android.hardware.nfc" android:required="false"/>
 
     <uses-permission
         android:name="android.permission.READ_CONTACTS"

--- a/app/src/main/java/io/digibyte/presenter/activities/PaperKeyProveActivity.java
+++ b/app/src/main/java/io/digibyte/presenter/activities/PaperKeyProveActivity.java
@@ -47,9 +47,14 @@ public class PaperKeyProveActivity extends BRActivity implements TextView.OnEdit
                         getString(R.string.Alerts_paperKeySet),
                         getString(R.string.Alerts_paperKeySetSubheader),
                         R.raw.success_check, () -> {
-                            BRAnimator.startBreadActivity(PaperKeyProveActivity.this, false);
-                            overridePendingTransition(R.anim.enter_from_right, R.anim.exit_to_left);
-                            finishAffinity();
+                            if (BRSharedPrefs.digiIDFocus(PaperKeyProveActivity.this)) {
+                                BRAnimator.startBreadActivity(PaperKeyProveActivity.this, true);
+                            } else {
+                                BRAnimator.startBreadActivity(PaperKeyProveActivity.this, false);
+                                overridePendingTransition(R.anim.enter_from_right,
+                                        R.anim.exit_to_left);
+                                finishAffinity();
+                            }
                         });
             } else {
                 if (!isWordCorrect(true)) {

--- a/app/src/main/java/io/digibyte/presenter/activities/callbacks/IntroActivityCallback.java
+++ b/app/src/main/java/io/digibyte/presenter/activities/callbacks/IntroActivityCallback.java
@@ -3,4 +3,6 @@ package io.digibyte.presenter.activities.callbacks;
 public interface IntroActivityCallback {
     void onNewWalletClick();
     void onRestoreClick();
+
+    void onNewDigiIDClick();
 }

--- a/app/src/main/java/io/digibyte/presenter/activities/intro/IntroActivity.java
+++ b/app/src/main/java/io/digibyte/presenter/activities/intro/IntroActivity.java
@@ -13,8 +13,8 @@ import io.digibyte.databinding.ActivityIntroBinding;
 import io.digibyte.presenter.activities.UpdatePinActivity;
 import io.digibyte.presenter.activities.callbacks.IntroActivityCallback;
 import io.digibyte.presenter.activities.util.BRActivity;
+import io.digibyte.tools.manager.BRSharedPrefs;
 import io.digibyte.tools.security.BRKeyStore;
-import io.digibyte.tools.security.PostAuth;
 import io.digibyte.tools.security.SmartValidator;
 import io.digibyte.wallet.BRWalletManager;
 
@@ -57,6 +57,12 @@ public class IntroActivity extends BRActivity implements Serializable {
             Intent intent = new Intent(IntroActivity.this, RecoverActivity.class);
             startActivity(intent);
             overridePendingTransition(R.anim.enter_from_right, R.anim.exit_to_left);
+        }
+
+        @Override
+        public void onNewDigiIDClick() {
+            BRSharedPrefs.setDigiIDFocus(IntroActivity.this);
+            UpdatePinActivity.open(IntroActivity.this, UpdatePinActivity.Mode.SET_PIN);
         }
     };
 

--- a/app/src/main/java/io/digibyte/presenter/activities/intro/WriteDownActivity.java
+++ b/app/src/main/java/io/digibyte/presenter/activities/intro/WriteDownActivity.java
@@ -11,6 +11,7 @@ import io.digibyte.databinding.ActivityWriteDownBinding;
 import io.digibyte.presenter.activities.callbacks.ActivityWriteDownCallback;
 import io.digibyte.presenter.activities.util.BRActivity;
 import io.digibyte.tools.animation.BRAnimator;
+import io.digibyte.tools.manager.BRSharedPrefs;
 import io.digibyte.tools.security.AuthManager;
 import io.digibyte.tools.security.PostAuth;
 
@@ -40,7 +41,8 @@ public class WriteDownActivity extends BRActivity {
         switch(item.getItemId()) {
             case R.id.home:
             case android.R.id.home:
-                BRAnimator.startBreadActivity(WriteDownActivity.this, false);
+                BRAnimator.startBreadActivity(WriteDownActivity.this,
+                        BRSharedPrefs.digiIDFocus(this));
                 return true;
             default:
                 return false;
@@ -50,7 +52,7 @@ public class WriteDownActivity extends BRActivity {
     @Override
     public void onBackPressed() {
         super.onBackPressed();
-        BRAnimator.startBreadActivity(WriteDownActivity.this, false);
+        BRAnimator.startBreadActivity(WriteDownActivity.this, BRSharedPrefs.digiIDFocus(this));
     }
 
     @Override

--- a/app/src/main/java/io/digibyte/tools/manager/BRSharedPrefs.java
+++ b/app/src/main/java/io/digibyte/tools/manager/BRSharedPrefs.java
@@ -514,4 +514,18 @@ public class BRSharedPrefs {
         SharedPreferences prefs = context.getSharedPreferences(BRConstants.PREFS_NAME, Context.MODE_PRIVATE);
         return prefs.contains("new_storage");
     }
+
+    public static void setDigiIDFocus(Context context) {
+        SharedPreferences prefs = context.getSharedPreferences(BRConstants.PREFS_NAME,
+                Context.MODE_PRIVATE);
+        SharedPreferences.Editor editor = prefs.edit();
+        editor.putBoolean("digi_id_focus", true);
+        editor.apply();
+    }
+
+    public static boolean digiIDFocus(Context context) {
+        SharedPreferences prefs = context.getSharedPreferences(BRConstants.PREFS_NAME,
+                Context.MODE_PRIVATE);
+        return prefs.getBoolean("digi_id_focus", false);
+    }
 }

--- a/app/src/main/java/io/digibyte/wallet/BRWalletManager.java
+++ b/app/src/main/java/io/digibyte/wallet/BRWalletManager.java
@@ -96,6 +96,7 @@ public class BRWalletManager {
     private static final String TAG = BRWalletManager.class.getName();
     private static String DIGIEXPLORER_URL = "https://explorer-1.us.digibyteservers.io";
     private static final String DIGIEXPLORER_URL_FALLBACK = "https://explorer-2.us.digibyteservers.io";
+    private static final String DIGIEXPLORER_URL_FALLBACK_2 = "https://digiexplorer.info/";
 
     private static BRWalletManager instance;
     public List<OnBalanceChanged> balanceListeners;
@@ -646,7 +647,19 @@ public class BRWalletManager {
             BRApiManager.getInstance().getBlockInfo(
                     DigiByte.getContext(), DIGIEXPLORER_URL);
         } catch(Exception e) {
-            DIGIEXPLORER_URL = DIGIEXPLORER_URL_FALLBACK;
+            try {
+                BRApiManager.getInstance().getBlockInfo(
+                        DigiByte.getContext(), DIGIEXPLORER_URL_FALLBACK);
+                DIGIEXPLORER_URL = DIGIEXPLORER_URL_FALLBACK;
+            } catch (Exception ee) {
+                try {
+                    BRApiManager.getInstance().getBlockInfo(
+                            DigiByte.getContext(), DIGIEXPLORER_URL_FALLBACK_2);
+                    DIGIEXPLORER_URL = DIGIEXPLORER_URL_FALLBACK_2;
+                } catch (Exception eee) {
+                    DIGIEXPLORER_URL = "WTF??";
+                }
+            }
         }
     }
 

--- a/app/src/main/res/layout/activity_intro.xml
+++ b/app/src/main/res/layout/activity_intro.xml
@@ -41,20 +41,37 @@
             android:gravity="center_horizontal" android:orientation="vertical">
             <Button
                 style="@style/ButtonTheme"
-                android:id="@+id/button_new_wallet"
+                android:id="@+id/button_new_digi_id"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:onClick="@{() -> callback.onNewWalletClick()}"
-                android:text="@string/MenuViewController.createButton"/>
+                android:onClick="@{() -> callback.onNewDigiIDClick()}"
+                android:text="@string/MenuViewController.createDigiIDButton"/>
 
-            <TextView
-                style="@style/ClickableText"
-                android:id="@+id/button_recover_wallet"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:onClick="@{() -> callback.onRestoreClick()}"
-                android:foreground="?android:attr/selectableItemBackground"
-                android:text="@string/RecoverWallet.header"/>
+            <LinearLayout android:layout_width="match_parent"
+                          android:layout_height="wrap_content" android:orientation="horizontal">
+
+                <TextView
+                    style="@style/ClickableText"
+                    android:id="@+id/button_new_wallet"
+                    android:layout_width="0dip"
+                    android:layout_weight="1"
+                    android:gravity="center_horizontal"
+                    android:layout_height="wrap_content"
+                    android:onClick="@{() -> callback.onNewWalletClick()}"
+                    android:foreground="?android:attr/selectableItemBackground"
+                    android:text="@string/MenuViewController.createButton"/>
+                <TextView
+                    style="@style/ClickableText"
+                    android:id="@+id/button_recover_wallet"
+                    android:layout_width="0dip"
+                    android:layout_weight="1"
+                    android:gravity="center_horizontal"
+                    android:layout_height="wrap_content"
+                    android:onClick="@{() -> callback.onRestoreClick()}"
+                    android:foreground="?android:attr/selectableItemBackground"
+                    android:text="@string/RecoverWallet.header"/>
+
+            </LinearLayout>
 
         </LinearLayout>
 

--- a/app/src/main/res/layout/activity_paper_key_prove.xml
+++ b/app/src/main/res/layout/activity_paper_key_prove.xml
@@ -68,7 +68,7 @@
                     android:layout_marginEnd="@dimen/bread_margin"
                     android:layout_marginStart="@dimen/bread_margin"
                     android:background="@drawable/dashed_edittext_underline"
-                    android:inputType="textPersonName"
+                    android:inputType="textNoSuggestions"
                     android:minHeight="50dp"
                     android:paddingEnd="20dp"
                     android:paddingStart="20dp"
@@ -94,10 +94,11 @@
                     android:layout_marginStart="@dimen/bread_margin"
                     android:background="@drawable/dashed_edittext_underline"
                     android:imeOptions="actionSend"
-                    android:inputType="textPersonName"
+                    android:inputType="textNoSuggestions"
                     android:minHeight="50dp"
                     android:paddingEnd="20dp"
                     android:paddingStart="20dp"
+
                     android:textColor="@color/white"
                     app:addTextChangedListener="@{textWatcher}"
                     app:setOnEditorActionListener="@{(textView, id, keyEvent) -> editorActionListener.onEditorAction(textView, id, keyEvent)}"/>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -95,6 +95,8 @@
   <!-- Menu button title -->
   <string name="MenuButton.settings">Settings</string>
   <!-- button label -->
+  <string name="MenuViewController.createDigiIDButton">Create New Digi-ID</string>
+  <!-- button label -->
   <string name="MenuViewController.createButton">Create New Wallet</string>
   <!-- button label -->
   <string name="MenuViewController.recoverButton">Recover Wallet</string>


### PR DESCRIPTION
 It causes the main wallet to be bypassed after seed phrase confirm screens are completed.