### PR TITLE
Fix Google Play link (from Wallabag to DigiByte)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <h1 margin="0 auto">DigiByte for Android</h1>
     
-<a href="https://play.google.com/store/apps/details?id=fr.gaulupeau.apps.InThePoche">
+<a href="https://play.google.com/store/apps/details?id=io.digibyte">
     <img alt="Get it on Google Play"
         height="80"
         src="https://play.google.com/intl/en_us/badges/images/generic/en_badge_web_generic.png"/>


### PR DESCRIPTION
Not entirely sure why it's linking to Wallabag 🤷 